### PR TITLE
Fix spelling of "Eastown"

### DIFF
--- a/data/links.yml
+++ b/data/links.yml
@@ -1,7 +1,7 @@
 ---
 
 - restaurant: Terra GR
-  neighborhood: Easttown
+  neighborhood: Eastown
   delivery: false
   takeout: true
   curbside: false
@@ -157,7 +157,7 @@
   notes:
 
 - restaurant: Chez Olga
-  neighborhood: Easttown
+  neighborhood: Eastown
   delivery: false
   takeout: true
   curbside: false
@@ -193,7 +193,7 @@
   notes:
 
 - restaurant: GR Bagel
-  neighborhood: Easttown
+  neighborhood: Eastown
   delivery: true
   takeout: true
   curbside: false
@@ -687,7 +687,7 @@
   notes:
 
 - restaurant: Matchbox Diner
-  neighborhood: Easttown
+  neighborhood: Eastown
   delivery: false
   takeout: true
   curbside: false
@@ -712,7 +712,7 @@
   notes:
 
 - restaurant: The Little Bird
-  neighborhood: Easttown
+  neighborhood: Eastown
   delivery: true
   takeout: true
   curbside: false


### PR DESCRIPTION
It technically only has one T: https://en.wikipedia.org/wiki/Eastown,_Grand_Rapids